### PR TITLE
Enable CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Run tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[test]
+    - name: Check for syntax errors and lint with flake8
+      run: |
+        # check for important errors:
+        # - syntax errors (E9),
+        # - confusion between assignment and equality errors (F63),
+        # - logic errors and syntax errors in type hints (F7)
+        # - undefined name errors (F82)
+        flake8 . \
+            --count --select=E9,F63,F7,F82 --show-source --statistics
+        # display all other linting errors, but never return an error code
+        flake8 . \
+            --exit-zero \
+            --count \
+            --statistics
+    - name: Run tests with pytest
+      run: |
+        py.test -rs -vvv  --durations=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,5 @@ jobs:
             --statistics
     - name: Run tests with pytest
       run: |
-        py.test -rs -vvv  --durations=0
+        # run tests with pytest, reporting coverage and timings
+        py.test -rs -vvv  --durations=0 --cov=./modnet/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+eggs/
+.eggs/
+sdist/
+wheels/
+*.egg-info/
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.coverage
+.coverage.*
+.cache
+coverage.xml
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# VSCode project settings
+.vscode
+
+# mkdocs documentation
+/site
+
+# pytest
+.pytest_cache/
+
+# Mac
+.DS_Store
+.idea/
+
+# Package-specific
+local_openapi.json
+local_index_openapi.json
+logs

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,21 @@ import re
 
 with open("README.md", "r") as f:
     long_description = f.read()
-    
+
 with open("modnet/__init__.py", "r") as f:
     lines = ""
     for item in f.readlines():
         lines += item + '\n'
 
 
-
 version = re.search('__version__ = "(.*)"', lines).group(1)
-    
+
+tests_require = [
+    "pytest>=6.0",
+    "pytest-cov>=2.10",
+    "flake8>=3.8"
+]
+
 setuptools.setup(
     name="modnet",
     version=version,
@@ -32,6 +37,9 @@ setuptools.setup(
           'numpy>=1.18.3',
           'scikit-learn'
         ],
+    tests_require=tests_require,
+    test_suite="modnet.tests",
+    extras_require={"test": tests_require},
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
This PR enables a barebones GitHub Actions CI that does the following:

- [x] Checks for syntax errors and a few other bits of Python nastiness with flake8, raising an error if it finds any
- [x] Prints all flake8 linting errors/warnings, without raising an error (some of which we may want to fix at a later date, at which point we can turn on the error raising)
- [x] Runs the few unit tests at the moment with pytest, and reports overall test coverage (we can add an upload to a coverage service like codecov in the future)