### PR TITLE
Enabled missing BagofBonds featurizer

### DIFF
--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -324,7 +324,8 @@ def featurize_structure(df):
                                      StructuralHeterogeneity(),
                                      MaximumPackingEfficiency(),
                                      ChemicalOrdering(),
-                                     XRDPowderPattern()
+                                     XRDPowderPattern(),
+                                     bob
                                      ])
 
 


### PR DESCRIPTION
Just noticed that `BagofBonds` was not being used in the structure featurizer method, think its worth fixing this here in a separate PR rather than the change getting lost in the bigger PR.