### PR TITLE
Refactoring of MODNetModel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.8

--- a/modnet/data/feature_database.pkl.zip
+++ b/modnet/data/feature_database.pkl.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16bace6b6401929e6d00667028fee133ca9c2a8b94a1e93aa60ae0bba93f4186
-size 266254181

--- a/modnet/model_presets/presets.py
+++ b/modnet/model_presets/presets.py
@@ -2,13 +2,17 @@ batch_sizes = [64]
 
 learning_rates = [0.02, 0.005]
 
-archs = [(350,[[64],[8],[8],[]]),(350,[[256],[128],[8],[8]]),(1000,[[256],[128],[8],[]])]
+archs = [
+    (350, [[64], [8], [8], []]),
+    (350, [[256], [128], [8], [8]]),
+    (1000, [[256], [128], [8], []]),
+]
 
 epochs = [1000]
 
-losses = ['mse']
+losses = ["mse"]
 
-activations = ['elu']
+activations = ["elu"]
 
 hyperparam_presets = []
 for bs in batch_sizes:
@@ -16,6 +20,14 @@ for bs in batch_sizes:
         for a in archs:
             for e in epochs:
                 for l in losses:
-                    for act in  activations:
-                        preset = {'batch_size':bs, 'lr':lr, 'n_feat':a[0], 'num_neurons':a[1], 'epochs':e, 'loss':l, 'act':act}
+                    for act in activations:
+                        preset = {
+                            "batch_size": bs,
+                            "lr": lr,
+                            "n_feat": a[0],
+                            "num_neurons": a[1],
+                            "epochs": e,
+                            "loss": l,
+                            "act": act,
+                        }
                         hyperparam_presets.append(preset)

--- a/modnet/models.py
+++ b/modnet/models.py
@@ -157,7 +157,7 @@ class MODNetModel:
         epochs: int = 200,
         batch_size: int = 128,
         xscale: Optional[str] = "minmax",
-        metrics: Tuple[str] = ("mae",),
+        metrics: List[str] = ["mae"],
         callbacks: List[Callable] = None,
         verbose: int = 0,
         loss: str = "mse",
@@ -201,7 +201,7 @@ class MODNetModel:
         x = training_data.get_featurized_df()[
             self.optimal_descriptors[:self.n_feat]
         ].values
-        y = training_data.get_target_df()[self.targets_flatten].values.astype(np.float, copy=False)
+        y = [training_data.df_targets[targ].values.astype(np.float, copy=False) for targ in self.targets_flatten]
 
         # Scale the input features:
         if self.xscale == "minmax":

--- a/modnet/models.py
+++ b/modnet/models.py
@@ -1,213 +1,442 @@
+import pickle
 import logging
-logging.getLogger().setLevel(logging.INFO)
+from typing import List, Tuple, Dict, Optional, Callable
+
 import pandas as pd
 import numpy as np
-import tensorflow as tf
-from tensorflow.keras.layers import Input, Dense, BatchNormalization
-from tensorflow.keras.callbacks import EarlyStopping, LambdaCallback, ModelCheckpoint, ReduceLROnPlateau
+
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
-import pickle
-import tensorflow.keras.backend as K
-from tensorflow.keras.models import model_from_json
+import tensorflow.keras as keras
+
 from modnet.preprocessing import MODData
 from modnet.model_presets import MODNET_PRESETS
+from modnet import __version__
+
+logging.getLogger().setLevel(logging.INFO)
+
+__all__ = ("MODNetModel",)
+
 
 class MODNetModel:
-    
-    def __init__(self,targets,weights,num_neurons=[[64],[32],[16],[16]], n_feat=300,act='relu'):
+    """Container class for the underlying Keras `Model`, that handles
+    setting up the architecture, activations, training and learning curve.
 
-        self.targets = targets
+    Attributes:
+        n_feat: The number of features used in the model.
+        weights: The relative loss weights for each target.
+        optimal_descriptors: The list of column names used
+            in training the model.
+        model: The `keras.model.Model` of the network itself.
+        target_names: The list of targets names that the model
+            was trained for.
+
+    """
+
+    def __init__(
+        self,
+        targets: List,
+        weights: Dict[str, float],
+        num_neurons=([64], [32], [16], [16]),
+        n_feat=300,
+        act="relu",
+    ):
+        """Initialise the model on the passed targets with the desired
+        architecture, feature count and loss functions and activation functions.
+
+        Parameters:
+            targets: A nested list of targets names that defines the hierarchy
+                of the output layers.
+            weights: The relative loss weights to apply for each target.
+            num_neurons: A specification of the model layers, as a 4-tuple
+                of lists of integers. Hidden layers are split into four
+                blocks of `keras.layers.Dense`, with neuron count specified
+                by the elements of the `num_neurons` argument.
+            n_feat: The number of features to use as model inputs.
+            act: A string defining a Keras activation function to pass to use
+                in the `keras.layers.Dense` layers.
+
+        """
+
+        self.__modnet_version__ = __version__
+
         self.n_feat = n_feat
         self.weights = weights
 
-        num_layers = [len(x) for x in num_neurons]
+        self._scaler = None
+        self.optimal_descriptors = None
+        self.target_names = None
+        self.model = None
 
         f_temp = [x for subl in targets for x in subl]
         self.targets_flatten = [x for subl in f_temp for x in subl]
-        
-        if len(self.targets_flatten) > 1:
-            self.PP = True
-        else:
-            self.PP = False
-    
+        self._multi_target = len(self.targets_flatten) > 1
 
-        #Build first common block
-        f_input = Input(shape=(n_feat,))
+        self.build_model(targets, n_feat, num_neurons, act=act)
+
+    def build_model(
+        self,
+        targets: List,
+        n_feat: int,
+        num_neurons: Tuple[List[int], List[int], List[int], List[int]],
+        act: str = "relu",
+    ):
+        """Builds the Keras model and sets the `self.model` attribute.
+
+        Parameters:
+            targets: A nested list of targets names that defines the hierarchy
+                of the output layers.
+            n_feat: The number of features to use as model inputs.
+            num_neurons: A specification of the model layers, as a 4-tuple
+                of lists of integers. Hidden layers are split into four
+                blocks of `keras.layers.Dense`, with neuron count specified
+                by the elements of the `num_neurons` argument.
+            act: A string defining a Keras activation function to pass to use
+                in the `keras.layers.Dense` layers.
+
+        """
+
+        num_layers = [len(x) for x in num_neurons]
+
+        # Build first common block
+        f_input = keras.layers.Input(shape=(n_feat,))
         previous_layer = f_input
         for i in range(num_layers[0]):
-            previous_layer = Dense(num_neurons[0][i],activation=act)(previous_layer)
-            if self.PP:
-                previous_layer = BatchNormalization()(previous_layer)
+            previous_layer = keras.layers.Dense(num_neurons[0][i], activation=act)(
+                previous_layer
+            )
+            if self._multi_target:
+                previous_layer = keras.layers.BatchNormalization()(previous_layer)
         common_out = previous_layer
 
-        # build intermediate representations
+        # Build intermediate representations
         intermediate_models_out = []
-        for i in range(len(targets)):
+        for _ in range(len(targets)):
             previous_layer = common_out
             for j in range(num_layers[1]):
-                previous_layer = Dense(num_neurons[1][j],activation=act)(previous_layer)
-                if self.PP:
-                    previous_layer = BatchNormalization()(previous_layer)
+                previous_layer = keras.layers.Dense(num_neurons[1][j], activation=act)(
+                    previous_layer
+                )
+                if self._multi_target:
+                    previous_layer = keras.layers.BatchNormalization()(previous_layer)
             intermediate_models_out.append(previous_layer)
 
-        #Build outputs
+        # Build outputs
         final_out = []
-        for group_idx,group in enumerate(targets):
+        for group_idx, group in enumerate(targets):
             for prop_idx in range(len(group)):
                 previous_layer = intermediate_models_out[group_idx]
                 for k in range(num_layers[2]):
-                    previous_layer = Dense(num_neurons[2][k],activation=act)(previous_layer)
-                    if self.PP:
-                        previous_layer = BatchNormalization()(previous_layer)
+                    previous_layer = keras.layers.Dense(
+                        num_neurons[2][k], activation=act
+                    )(previous_layer)
+                    if self._multi_target:
+                        previous_layer = keras.layers.BatchNormalization()(
+                            previous_layer
+                        )
                 clayer = previous_layer
-                temps = []
                 for pi in range(len(group[prop_idx])):
                     previous_layer = clayer
                     for li in range(num_layers[3]):
-                        previous_layer = Dense(num_neurons[3][li])(previous_layer)
-                    out = Dense(1,activation='linear',name=group[prop_idx][pi])(previous_layer)
+                        previous_layer = keras.layers.Dense(num_neurons[3][li])(
+                            previous_layer
+                        )
+                    out = keras.layers.Dense(
+                        1, activation="linear", name=group[prop_idx][pi]
+                    )(previous_layer)
                     final_out.append(out)
 
-        self.model = tf.keras.models.Model(inputs=f_input, outputs=final_out)
+        self.model = keras.models.Model(inputs=f_input, outputs=final_out)
 
-    def fit(self,data:MODData, val_fraction = 0.0, val_key = None, lr=0.001, epochs = 200, batch_size = 128, xscale='minmax', loss='mse', callbacks=None, verbose=1):
-        
-        if self.n_feat > len(data.get_optimal_descriptors()):
-            raise RuntimeError("The model requires more features than computed in data. Please reduce n_feat below or equal to {}".format(len(data.get_optimal_descriptors())))
+    def fit(
+        self,
+        training_data: MODData,
+        val_fraction: float = 0.0,
+        val_key: str = None,
+        lr: float = 0.001,
+        epochs: int = 200,
+        batch_size: int = 128,
+        xscale: Optional[str] = "minmax",
+        metrics: Tuple[str] = ("mae",),
+        callbacks: List[Callable] = None,
+        verbose: int = 0,
+        loss: str = "mse",
+        **fit_params,
+    ) -> None:
+        """Train the model on the passed training `MODData` object.
+
+        Paramters:
+            training_data: A `MODData` that has been featurized and
+                feature selected. The first `self.n_feat` entries in
+                `training_data.get_optimal_descriptors()` will be used
+                for training.
+            val_fraction: The fraction of the training data to use as a
+                validation set for tracking model performance during
+                training.
+            val_key: The target name to track on the validation set
+                during training, if performing multi-target learning.
+            lr: The learning rate.
+            epochs: The maximum number of epochs to train for.
+            batch_size: The batch size to use for training.
+            xscale: The feature scaler to use, either `None`,
+                `'minmax'` or `'standard'`.
+            metrics: A list of Keras metrics to pass to `compile(...)`.
+            loss: The built-in Keras loss to pass to `compile(...)`.
+            fit_params: Any additional parameters to pass to `fit(...)`,
+                these will be overwritten by the explicit keyword
+                arguments above.
+
+        """
+
+        if self.n_feat > len(training_data.get_optimal_descriptors()):
+            raise RuntimeError(
+                "The model requires more features than computed in data. "
+                f"Please reduce n_feat below or equal to {len(training_data.get_optimal_descriptors())}"
+            )
+
         self.xscale = xscale
-        self.target_names = data.names
-        self.optimal_descriptors = data.get_optimal_descriptors()
-        x = data.get_featurized_df()[self.optimal_descriptors[:self.n_feat]].values
-        #print(x.shape)
-        y = data.get_target_df()[self.targets_flatten].values.transpose()
-        #print(y.shape)
-        
-        #Scale the input features:
-        if self.xscale == 'minmax':
-            self.xmin = x.min(axis=0)
-            self.xmax = x.max(axis=0)
-            x=(x-self.xmin)/(self.xmax-self.xmin) - 0.5
-                
-        elif self.xscale == 'standard':
-            self.scaler = StandardScaler()
-            x = self.scaler.fit_transform(x)
+        self.target_names = training_data.names
+        self.optimal_descriptors = training_data.get_optimal_descriptors()
 
+        x = training_data.get_featurized_df()[
+            self.optimal_descriptors[: self.n_feat]
+        ].values
+        y = training_data.get_target_df()[self.targets_flatten].values.transpose()
+
+        # Scale the input features:
+        if self.xscale == "minmax":
+            self._scaler = MinMaxScaler()
+
+        elif self.xscale == "standard":
+            self._scaler = StandardScaler()
+
+        x = self._scaler.fit_transform(x)
         x = np.nan_to_num(x)
-        
-        if verbose and self.PP:
-            if val_fraction>0:
-                print_callback = LambdaCallback(
-                  on_epoch_end=lambda epoch,logs: print("epoch {}: loss: {:.3f}, val_loss:{:.3f} val_{}:{:.3f}".format(epoch,logs['loss'],logs['val_loss'],val_key,logs['val_{}_mae'.format(val_key)])))
-                verbose = 0
+
+        if val_fraction > 0:
+            if self._multi_target:
+                val_metric_key = f"val_{val_key}_mae"
             else:
-                print_callback = LambdaCallback(
-                    on_epoch_end=lambda epoch,logs: print("epoch {}: loss: {:.3f}".format(epoch,logs['loss'])))
-                verbose = 0
-            if callbacks is None:
-                callbacks = [print_callback]
-            else:
-                callbacks += [print_callback]
+                val_metric_key = "val_mae"
+            print_callback = keras.callbacks.LambdaCallback(
+                on_epoch_end=lambda epoch, logs: print(
+                    f"epoch {epoch}: loss: {logs['loss']:.3f}, "
+                    f"val_loss:{logs['val_loss']:.3f} {val_metric_key}:{logs[val_metric_key]:.3f}"
+                )
+            )
+
+        else:
+            print_callback = keras.callbacks.LambdaCallback(
+                on_epoch_end=lambda epoch, logs: print(
+                    "epoch {epoch}: loss: {logs['loss']:.3f}"
+                )
+            )
+
+        if callbacks is None:
+            callbacks = [print_callback]
+        else:
+            callbacks.append(print_callback)
 
         fit_params = {
-            'x': x,
-            'y': list(y),
-            'epochs': epochs,
-            'batch_size': batch_size,
-            'verbose': verbose,
-            'validation_split': val_fraction,
-            'callbacks': callbacks
+            "x": x,
+            "y": list(y),
+            "epochs": epochs,
+            "batch_size": batch_size,
+            "verbose": verbose,
+            "validation_split": val_fraction,
+            "callbacks": callbacks,
         }
 
-        #print('compile',flush=True)
-        self.model.compile(loss = loss, optimizer=tf.keras.optimizers.Adam(lr=lr), metrics=['mae'], loss_weights=self.weights)
-        #print('fit',flush=True)
-        
-        history = self.model.fit(**fit_params)
+        logging.info("Compiling model...")
+        self.model.compile(
+            loss=loss,
+            optimizer=keras.optimizers.Adam(lr=lr),
+            metrics=metrics,
+            loss_weights=self.weights,
+        )
 
-        return history
+        logging.info("Fitting model...")
+        self.model.fit(**fit_params)
 
-
-    def fit_preset(self, data:MODData,verbose=0):
-        """
-        Chooses an optimal hyper-parametered MODNet model from different presets .
+    def fit_preset(self, data: MODData, verbose: int = 0) -> None:
+        """Chooses an optimal hyper-parametered MODNet model from different presets .
         The data is first fitted on several well working MODNet presets with a validation set (20% of the furnished data).
         The best validating preset is then fitted again on the whole data, and the current model is updated accordingly.
         Args:
             data: MODData object contain training and validation samples.
-
-        Returns: None, object is updated to fit the data.
+            verbose: verbosity level to pass to Keras
 
         """
-        rlr = ReduceLROnPlateau(monitor="loss", factor=0.5, patience=20, verbose=verbose, mode="auto", min_delta=0)
-        es = EarlyStopping(monitor="loss", min_delta=0.001, patience=300, verbose=verbose, mode="auto", baseline=None,
-                           restore_best_weights=True)
-        callbacks = [rlr,es]
+        rlr = keras.callbacks.ReduceLROnPlateau(
+            monitor="loss",
+            factor=0.5,
+            patience=20,
+            verbose=verbose,
+            mode="auto",
+            min_delta=0,
+        )
+        es = keras.callbacks.EarlyStopping(
+            monitor="loss",
+            min_delta=0.001,
+            patience=300,
+            verbose=verbose,
+            mode="auto",
+            baseline=None,
+            restore_best_weights=True,
+        )
+        callbacks = [rlr, es]
         val_losses = np.empty((len(MODNET_PRESETS),))
-        for i,params in enumerate(MODNET_PRESETS):
-            logging.info("Training preset #{}/{}".format(i+1,len(MODNET_PRESETS)))
-            n_feat = min(len(data.get_optimal_descriptors()),params['n_feat'])
-            self.model = MODNetModel(self.targets,self.weights,num_neurons=params['num_neurons'],n_feat=n_feat, act=params['act']).model
+
+        for i, params in enumerate(MODNET_PRESETS):
+            logging.info("Training preset #{}/{}".format(i + 1, len(MODNET_PRESETS)))
+            n_feat = min(len(data.get_optimal_descriptors()), params["n_feat"])
+            self.model = MODNetModel(
+                self.targets,
+                self.weights,
+                num_neurons=params["num_neurons"],
+                n_feat=n_feat,
+                act=params["act"],
+            ).model
             self.n_feat = n_feat
-            hist = self.fit(data, val_fraction=0.2, lr=params['lr'], epochs=params['epochs'], batch_size=params['batch_size'], loss=params['loss'], callbacks=callbacks, verbose=verbose)
-            val_loss = np.array(hist.history['val_loss'])[-20:].mean()
+            hist = self.fit(
+                data,
+                val_fraction=0.2,
+                lr=params["lr"],
+                epochs=params["epochs"],
+                batch_size=params["batch_size"],
+                loss=params["loss"],
+                callbacks=callbacks,
+                verbose=verbose,
+            )
+            val_loss = np.array(hist.history["val_loss"])[-20:].mean()
             val_losses[i] = val_loss
             logging.info("Validation loss: {:.3f}".format(val_loss))
         best_preset = val_losses.argmin()
-        logging.info("Preset #{} resulted in lowest validation loss.\nFitting all data...".format(best_preset+1))
-        n_feat = min(len(data.get_optimal_descriptors()), MODNET_PRESETS[best_preset]['n_feat'])
-        self.model = MODNetModel(self.targets, self.weights, num_neurons=MODNET_PRESETS[best_preset]['num_neurons'], n_feat=n_feat,
-                                 act=MODNET_PRESETS[best_preset]['act']).model
+        logging.info(
+            "Preset #{} resulted in lowest validation loss.\nFitting all data...".format(
+                best_preset + 1
+            )
+        )
+        n_feat = min(
+            len(data.get_optimal_descriptors()), MODNET_PRESETS[best_preset]["n_feat"]
+        )
+        self.model = MODNetModel(
+            self.targets,
+            self.weights,
+            num_neurons=MODNET_PRESETS[best_preset]["num_neurons"],
+            n_feat=n_feat,
+            act=MODNET_PRESETS[best_preset]["act"],
+        ).model
         self.n_feat = n_feat
-        self.fit(data, val_fraction=0.2, lr=MODNET_PRESETS[best_preset]['lr'], epochs=MODNET_PRESETS[best_preset]['epochs'],
-                        batch_size=MODNET_PRESETS[best_preset]['batch_size'], loss=MODNET_PRESETS[best_preset]['loss'], callbacks=callbacks, verbose=verbose)
+        self.fit(
+            data,
+            val_fraction=0.2,
+            lr=MODNET_PRESETS[best_preset]["lr"],
+            epochs=MODNET_PRESETS[best_preset]["epochs"],
+            batch_size=MODNET_PRESETS[best_preset]["batch_size"],
+            loss=MODNET_PRESETS[best_preset]["loss"],
+            callbacks=callbacks,
+            verbose=verbose,
+        )
+
+    def predict(self, test_data: MODData) -> pd.DataFrame:
+        """Predict the target values for the passed MODData.
+
+        Parameters:
+            test_data: A featurized and feature-selected `MODData`
+                object containing the descriptors used in training.
+
+        Returns:
+            A `pandas.DataFrame` containing the predicted values of the targets.
 
 
-    def predict(self,data):
-        
-        x = data.get_featurized_df()[self.optimal_descriptors[:self.n_feat]].values
-        
-        #Scale the input features:
-        if self.xscale == 'minmax':
-            x=(x-self.xmin)/(self.xmax-self.xmin) - 0.5
-                
-        elif self.xscale == 'standard':
+        """
+
+        x = test_data.get_featurized_df()[
+            self.optimal_descriptors[: self.n_feat]
+        ].values
+
+        # Scale the input features:
+        if self._scaler is not None:
             x = self.scaler.transform(x)
-        
+
         x = np.nan_to_num(x)
-        
-        if self.PP:
-            p = np.array(self.model.predict(x))[:,:,0].transpose()
+
+        if self._multi_target:
+            p = np.array(self.model.predict(x))[:, :, 0].transpose()
         else:
-            p = np.array(self.model.predict(x))[:,0].transpose()
+            p = np.array(self.model.predict(x))[:, 0].transpose()
+
         predictions = pd.DataFrame(p)
         predictions.columns = self.targets_flatten
-        predictions.index = data.structure_ids
-        
+        predictions.index = test_data.structure_ids
+
         return predictions
-    
-    
-    def save(self,filename):
+
+    def save(self, filename: str):
+        """Save the `MODNetModel` across 3 files with the same base
+        filename:
+
+        * <filename>.json contains the Keras model JSON dump.
+        * <filename>.pkl contains the `MODNetModel` object, excluding the
+          Keras model.
+        * <filename>.h5 contains the model weights.
+
+        Parameters:
+            filename: The base filename to save to.
+
+        """
+
+        logging.info("Saving model...")
+        model_json = self.model.to_json()
+        with open(f"{filename}.json", "w") as f:
+            f.write(model_json)
+        self.model.save_weights(f"{filename}.h5")
+
         model = self.model
         self.model = None
-        model_json = model.to_json()
-        fp = open('{}.json'.format(filename), 'w')
-        fp.write(model_json)
-        fp.close()
-        model.save_weights('{}.h5'.format(filename))
-        fp = open('{}.pkl'.format(filename),'wb')
-        pickle.dump(self,fp)
-        fp.close()
+        with open(f"{filename}.pkl", "wb") as f:
+            pickle.dump(self, f)
         self.model = model
-        print('Saved model')
-    
+        logging.info("Saved model to {}(.json/.h5/.pkl)".format(filename))
+
     @staticmethod
-    def load(filename):
-        fp = open('{}.pkl'.format(filename),'rb')
-        mod = pickle.load(fp)
-        fp.close()
-        fp = open('{}.json'.format(filename), 'r')
-        model_json = fp.read()
-        fp.close()
-        mod.model = model_from_json(model_json)
-        mod.model.load_weights('{}.h5'.format(filename))
+    def load(filename: str):
+        """Load the `MODNetModel` from 3 files with the same base
+        filename:
+
+        * <filename>.json contains the Keras model JSON dump.
+        * <filename>.pkl contains the `MODNetModel` object, excluding the
+          Keras model.
+        * <filename>.h5 contains the model weights.
+
+        Returns:
+            The loaded `MODNetModel` object.
+
+        """
+
+        logging.info("Loading model from {}(.json/.h5/.pkl)".format(filename))
+
+        with open(f"{filename}.pkl", "rb") as f:
+            mod = pickle.load(f)
+
+        if not isinstance(mod, MODNetModel):
+            raise RuntimeError(
+                "Pickled data in {filename}.pkl did not contain a `MODNetModel`."
+            )
+
+        with open(f"{filename}.json", "r") as f:
+            model_json = f.read()
+
+        mod.model = keras.models.model_from_json(model_json)
+        mod.model.load_weights(f"{filename}.h5")
+
+        if not hasattr(mod, "__modnet_version__"):
+            mod.__modnet_version__ = "<=0.1.7"
+
+        logging.info(
+            "Loaded `MODNetModel` created with modnet version {}.".format(
+                mod.__modnet_version__
+            )
+        )
+
         return mod

--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -790,7 +790,7 @@ class MODData:
             setattr(split_data, attr, getattr(self, attr).iloc[indices])
 
         for attr in [_ for _ in dir(self) if _ not in extensive_dataframes]:
-            if not callable(attr) and not attr.startswith("__"):
+            if not callable(getattr(self, attr)) and not attr.startswith("__"):
                 try:
                     setattr(split_data, attr, getattr(self, attr))
                 except AttributeError:

--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -503,7 +503,7 @@ class MODData:
         self.df_structure = pd.DataFrame({'id': structure_ids, 'structure': structures})
         self.df_structure.set_index('id', inplace=True)
 
-    def featurize(self, fast: bool = False, db_file: str = 'feature_database.pkl'):
+    def featurize(self, fast: bool = False, db_file: str = 'feature_database.pkl', n_jobs=None):
         """ For the input structures, construct many matminer features
         and save a featurized dataframe. If `db_file` is specified, this
         method will try to load previous feature calculations for each
@@ -522,6 +522,9 @@ class MODData:
 
         df_done = None
         df_todo = None
+
+        if n_jobs is not None:
+            self.featurizer.set_n_jobs(n_jobs)
 
         if self.df_featurized is not None:
             raise RuntimeError("Not overwriting existing featurized dataframe.")

--- a/modnet/tests/conftest.py
+++ b/modnet/tests/conftest.py
@@ -32,7 +32,7 @@ def _load_moddata(filename):
     return MODData.load(data_file)
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def subset_moddata():
     """Loads the 100-structure featurized subset of MP.2018.6 for use
     in other tests, checking only the hash.
@@ -41,7 +41,7 @@ def subset_moddata():
     return _load_moddata("MP_2018.6_subset.zip")
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def small_moddata():
     """Loads the small 5-structure featurized subset of MP.2018.6 for use
     in other tests, checking only the hash.

--- a/modnet/tests/conftest.py
+++ b/modnet/tests/conftest.py
@@ -48,3 +48,15 @@ def small_moddata():
 
     """
     return _load_moddata("MP_2018.6_small.zip")
+
+
+@pytest.fixture(scope="module")
+def tf_session():
+    """This fixture can be used to sandbox tests that require tensorflow."""
+    import tensorflow
+
+    tensorflow.compat.v1.disable_eager_execution()
+    with tensorflow.device("/device:CPU:0") as session:
+        yield session
+
+    tensorflow.keras.backend.clear_session()

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+import pytest
+
+def test_train_small_model_single_target(subset_moddata):
+    """Tests the single target training."""
+    from modnet.models import MODNetModel
+
+    data = subset_moddata
+    # set 'optimal' features manually
+    data.optimal_features = [
+        col for col in data.df_featurized.columns if col.startswith("ElementProperty")
+    ]
+
+    model = MODNetModel(
+        [[["eform"]]],
+        weights={"eform": 1},
+        num_neurons=([16], [8], [8], [4]),
+        n_feat=10,
+    )
+
+    model.fit(data, epochs=5)
+    model.predict(data)
+
+
+def test_train_small_model_multi_target(subset_moddata):
+    """Tests the multi-target training."""
+    from modnet.models import MODNetModel
+
+    data = subset_moddata
+    # set 'optimal' features manually
+    data.optimal_features = [
+        col for col in data.df_featurized.columns if col.startswith("ElementProperty")
+    ]
+
+    model = MODNetModel(
+        [[["eform", "egap"]]],
+        weights={"eform": 1, "egap": 1},
+        num_neurons=([16], [8], [8], [4]),
+        n_feat=10,
+    )
+
+    model.fit(data, epochs=5)
+    model.predict(data)
+
+
+def test_train_small_model_presets(subset_moddata):
+    """Tests the `fit_preset()` method."""
+    from modnet.model_presets import MODNET_PRESETS
+    from modnet.models import MODNetModel
+
+    for ind, preset in enumerate(MODNET_PRESETS):
+        MODNET_PRESETS[ind]["epochs"] = 5
+
+    data = subset_moddata
+    # set 'optimal' features manually
+    data.optimal_features = [
+        col for col in data.df_featurized.columns if col.startswith("ElementProperty")
+    ]
+
+    model = MODNetModel(
+        [[["eform", "egap"]]],
+        weights={"eform": 1, "egap": 1},
+        num_neurons=([16], [8], [8], [4]),
+        n_feat=10,
+    )
+
+    model.fit_preset(data)
+
+@pytest.mark.skip(msg="Until pickle bug is fixed")
+def test_model_integration(subset_moddata):
+    """Tests training, saving, loading and predictions."""
+    from modnet.models import MODNetModel
+
+    data = subset_moddata
+    # set 'optimal' features manually
+    data.optimal_features = [
+        col for col in data.df_featurized.columns if col.startswith("ElementProperty")
+    ][:10]
+
+    model = MODNetModel(
+        [[["eform", "egap"]]],
+        weights={"eform": 1, "egap": 1},
+        num_neurons=([16], [8], [8], [4]),
+        n_feat=10,
+    )
+
+    model.fit(data, epochs=5)
+
+    model.save("test")
+    loaded_model = MODNetModel.load("test")
+
+    assert model.predict(data) == loaded_model.predict(data)

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import pytest
 
+
 def test_train_small_model_single_target(subset_moddata):
     """Tests the single target training."""
     from modnet.models import MODNetModel
@@ -45,11 +46,14 @@ def test_train_small_model_multi_target(subset_moddata):
 
 def test_train_small_model_presets(subset_moddata):
     """Tests the `fit_preset()` method."""
+    from copy import deepcopy
     from modnet.model_presets import MODNET_PRESETS
     from modnet.models import MODNetModel
 
-    for ind, preset in enumerate(MODNET_PRESETS):
-        MODNET_PRESETS[ind]["epochs"] = 5
+    modified_presets = deepcopy(MODNET_PRESETS)
+
+    for ind, preset in enumerate(modified_presets):
+        modified_presets[ind]["epochs"] = 5
 
     data = subset_moddata
     # set 'optimal' features manually
@@ -64,7 +68,8 @@ def test_train_small_model_presets(subset_moddata):
         n_feat=10,
     )
 
-    model.fit_preset(data)
+    model.fit_preset(data, presets=modified_presets, val_fraction=0.2)
+
 
 @pytest.mark.skip(msg="Until pickle bug is fixed")
 def test_model_integration(subset_moddata):

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -2,7 +2,7 @@
 import pytest
 
 
-def test_train_small_model_single_target(subset_moddata):
+def test_train_small_model_single_target(subset_moddata, tf_session):
     """Tests the single target training."""
     from modnet.models import MODNetModel
 
@@ -23,7 +23,7 @@ def test_train_small_model_single_target(subset_moddata):
     model.predict(data)
 
 
-def test_train_small_model_multi_target(subset_moddata):
+def test_train_small_model_multi_target(subset_moddata, tf_session):
     """Tests the multi-target training."""
     from modnet.models import MODNetModel
 
@@ -44,7 +44,7 @@ def test_train_small_model_multi_target(subset_moddata):
     model.predict(data)
 
 
-def test_train_small_model_presets(subset_moddata):
+def test_train_small_model_presets(subset_moddata, tf_session):
     """Tests the `fit_preset()` method."""
     from copy import deepcopy
     from modnet.model_presets import MODNET_PRESETS
@@ -72,7 +72,7 @@ def test_train_small_model_presets(subset_moddata):
 
 
 @pytest.mark.skip(msg="Until pickle bug is fixed")
-def test_model_integration(subset_moddata):
+def test_model_integration(subset_moddata, tf_session):
     """Tests training, saving, loading and predictions."""
     from modnet.models import MODNetModel
 

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -211,7 +211,7 @@ def test_small_moddata_featurization(small_moddata):
 
     names = old.names
     new = MODData(structures, targets, target_names=names)
-    new.featurize(fast=False)
+    new.featurize(fast=False, n_jobs=2)
 
     new_cols = sorted(new.df_featurized.columns.tolist())
     old_cols = sorted(old.df_featurized.columns.tolist())

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -151,7 +151,7 @@ def test_get_cross_nmi():
     df_cross_nmi = get_cross_nmi(df_feat=df_feat, n_neighbors=2)
     assert df_cross_nmi.shape == (4, 4)
     expected = np.ones((4, 4))
-    expected[3, :] = expected[:, 3] = 0
+    expected[3, :] = expected[:, 3] = np.nan
     expected[3, 3] = np.nan
     np.testing.assert_allclose(
         np.array(df_cross_nmi, dtype=np.float64),

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -211,7 +211,7 @@ def test_small_moddata_featurization(small_moddata):
 
     names = old.names
     new = MODData(structures, targets, target_names=names)
-    new.featurize(fast=False, n_jobs=2)
+    new.featurize(fast=False, n_jobs=1)
 
     new_cols = sorted(new.df_featurized.columns.tolist())
     old_cols = sorted(old.df_featurized.columns.tolist())

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -294,11 +294,17 @@ def test_moddata_splits(subset_moddata):
         assert len(train.df_featurized) == 80
         assert len(train.df_targets) == 80
         assert len(train.df_structure) == 80
+        assert len(train.get_featurized_df()) == 80
+        assert len(train.get_structure_df()) == 80
+        assert len(train.get_target_df()) == 80
 
         assert len(test.structure_ids) == 20
         assert len(test.df_featurized) == 20
         assert len(test.df_targets) == 20
         assert len(test.df_structure) == 20
+        assert len(test.get_featurized_df()) == 20
+        assert len(test.get_structure_df()) == 20
+        assert len(test.get_target_df()) == 20
 
         test_id_set = set(test.structure_ids)
         for _id in train.structure_ids:


### PR DESCRIPTION
This PR tidies up the `modnet.models` module:

- [x] Lots of cosmetic changes, e.g. docstrings, type hints and refactoring of methods
- [x] Removed some remaining defunct files from git-lfs
- [x] No longer refit with `fit_preset`, just cache the best model
- [x] Added tests for simple model training/fit_preset/save/load
   - Seems like there is a bug with `.save()` and Python 3.8, where some multiprocessing object cannot be pickled
   - Fixed annoying tensorflow forking problem by running tests with only 1 multiprocessing job
- [x] Added ability to pass a `MODData` as `val_data` in `fit()` which gets transformed into `validation_data` for Keras.
- [x] Fixed bug with MODData splitting and `get_` methods