### PR TITLE
Some updates and fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
 modnet/data/feature_database.pkl filter=lfs diff=lfs merge=lfs -text
 moddata/refractive_index filter=lfs diff=lfs merge=lfs -text
-moddata/MP_2018.6 filter=lfs diff=lfs merge=lfs -text
-moddata/MP_2018.6.zip filter=lfs diff=lfs merge=lfs -text
 modnet/data/feature_database.pkl.zip filter=lfs diff=lfs merge=lfs -text

--- a/moddata/MP_2018.6.zip
+++ b/moddata/MP_2018.6.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68461ab8d21ad078a27fb7ec82c90783a6b2e20cb893def92db7d7e74e2a7c36
-size 386372146

--- a/modnet/__init__.py
+++ b/modnet/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.7"
+__version__ = "0.1.8~develop"

--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -606,6 +606,11 @@ class MODData:
         return list(self.df_targets)
 
     @property
+    def target_names(self) -> List[str]:
+        """ Returns the list of prediction target field names. """
+        return list(self.df_targets)
+
+    @property
     def structure_ids(self) -> List[str]:
         """ Returns the list of prediction target field names. """
         return list(self.df_structure.index)
@@ -703,4 +708,4 @@ class MODData:
         return self.optimal_features
 
     def get_optimal_df(self):
-        return self.df_featurized[self.optimal_features].join(self.targets)
+        return self.df_featurized[self.optimal_features].join(self.get_target_df())

--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -654,7 +654,7 @@ class MODData:
 
         if isinstance(pickled_data, MODData):
             if not hasattr(pickled_data, "__modnet_version__"):
-                pickled_data.__modnet_version__ = "<= 0.1.6"
+                pickled_data.__modnet_version__ = "<=0.1.7"
             logging.info(f"Loaded {pickled_data} object, created with modnet version {pickled_data.__modnet_version__}")
             return pickled_data
 

--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -78,7 +78,7 @@ def nmi_target(df_feat: pd.DataFrame, df_target: pd.DataFrame,
     # Prepare the output DataFrame and compute the mutual information
     target_name = df_target.columns[0]
     out_df = pd.DataFrame([], columns=[target_name], index=df_feat.columns)
-    out_df.loc[:, target_name] = (mutual_info_regression(df_feat, df_target[target_name], **kwargs))
+    out_df.loc[:, target_name] = mutual_info_regression(df_feat, df_target[target_name], **kwargs)
 
     # Compute the "self" mutual information (i.e. information entropy) of the target variable and of the input features
     target_mi = mutual_info_regression(df_target[target_name].values.reshape(-1, 1),
@@ -561,13 +561,13 @@ class MODData:
             if os.path.isfile(dp):
                 cross_nmi = pd.read_pickle(dp)
 
-        # if cross_nmi is None:
-        #        logging.info('Computing cross NMI between all features...')
-        #        df = self.df_featurized.copy()
-        #        cross_nmi = get_cross_nmi(df)
+        if cross_nmi is None:
+            logging.info('Computing cross NMI between all features...')
+            df = self.df_featurized.copy()
+            cross_nmi = get_cross_nmi(df)
 
         for i, name in enumerate(self.names):
-            logging.info("Starting target {}/{}: {} ...".format(i+1, len(self.names), self.names[i]))
+            logging.info(f"Starting target {i+1}/{len(self.names)}: {self.names[i]} ...")
 
             # Computing mutual information with target
             logging.info("Computing mutual information between features and target...")

--- a/modnet/tests/conftest.py
+++ b/modnet/tests/conftest.py
@@ -1,0 +1,50 @@
+import pytest
+from pathlib import Path
+
+from modnet.utils import get_hash_of_file
+
+
+_TEST_DATA_HASHES = {
+    "MP_2018.6_subset.zip": (
+        "d7d75e646dbde539645c8c0b065fd82cbe93f81d3500809655bd13d0acf2027c"
+        "1786091a73f53985b08868c5be431a3c700f7f1776002df28ebf3a12a79ab1a1"
+    ),
+    "MP_2018.6_small.zip": (
+        "937a29dad32d18e47c84eb7c735ed8af09caede21d2339c379032fbd40c463d8"
+        "ca377d9e3a777710b5741295765f6c12fbd7ab56f9176cc0ca11c9120283d878"
+    ),
+}
+
+
+def _load_moddata(filename):
+    """Loads the pickled MODData from the test directory and checks it's hash."""
+    from modnet.preprocessing import MODData
+
+    data_file = Path(__file__).parent.joinpath(f"data/{filename}")
+    if filename not in _TEST_DATA_HASHES:
+        raise RuntimeError(
+            f"Cannot verify hash of {filename} as it was not provided, will not load pickle."
+        )
+    # Loading pickles can be dangerous, so lets at least check that the MD5 matches
+    # what it was when created
+    assert get_hash_of_file(data_file) == _TEST_DATA_HASHES[filename]
+
+    return MODData.load(data_file)
+
+
+@pytest.fixture
+def subset_moddata():
+    """Loads the 100-structure featurized subset of MP.2018.6 for use
+    in other tests, checking only the hash.
+
+    """
+    return _load_moddata("MP_2018.6_subset.zip")
+
+
+@pytest.fixture
+def small_moddata():
+    """Loads the small 5-structure featurized subset of MP.2018.6 for use
+    in other tests, checking only the hash.
+
+    """
+    return _load_moddata("MP_2018.6_small.zip")

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
-
-
-from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
 
 from modnet.preprocessing import get_cross_nmi, nmi_target, MODData
-from .utils import get_sha512_of_file
 
 
 def test_nmi_target():
@@ -190,20 +186,11 @@ def test_get_cross_nmi():
     assert df_cross_nmi.loc['y']['x'] == pytest.approx(0.3417665092162398)
 
 
-def test_load_moddata_zip():
+def test_load_moddata_zip(subset_moddata):
     """ This test checks that older MODData objects can still be loaded. """
 
-    data_file = Path(__file__).parent.joinpath("data/MP_2018.6_subset.zip")
+    data = subset_moddata
 
-    # Loading pickles can be dangerous, so lets at least check that the MD5 matches
-    # what it was when created
-    assert (
-        get_sha512_of_file(data_file) ==
-        "d7d75e646dbde539645c8c0b065fd82cbe93f81d3500809655bd13d0acf2027c"
-        "1786091a73f53985b08868c5be431a3c700f7f1776002df28ebf3a12a79ab1a1"
-    )
-
-    data = MODData.load(data_file)
     assert len(data.structures) == 100
     assert len(data.mpids) == 100
     assert len(data.df_structure) == 100
@@ -212,19 +199,10 @@ def test_load_moddata_zip():
     assert len(data.df_targets) == 100
 
 
-def test_small_moddata_featurization():
+def test_small_moddata_featurization(small_moddata):
     """ This test creates a new MODData from the MP 2018.6 structures. """
-    data_file = Path(__file__).parent.joinpath("data/MP_2018.6_small.zip")
 
-    # Loading pickles can be dangerous, so lets at least check that the MD5 matches
-    # what it was when created
-    assert (
-        get_sha512_of_file(data_file) ==
-        "937a29dad32d18e47c84eb7c735ed8af09caede21d2339c379032"
-        "fbd40c463d8ca377d9e3a777710b5741295765f6c12fbd7ab56f9176cc0ca11c9120283d878"
-    )
-
-    old = MODData.load(data_file)
+    old = small_moddata
     structures = old.structures
     targets = old.targets
 
@@ -289,3 +267,12 @@ def test_merge_ranked():
 
     expected = ["a", "d", "c", "b", 0, 2, "e", "g", "0"]
     assert merge_ranked(test_features) == expected
+
+def test_load_precomputed():
+    """Tries to load and unpack the dataset on figshare.
+
+    Requies ~10 GB of memory.
+
+    """
+
+    MODData.load_precomputed("MP_2018.6")

--- a/modnet/utils.py
+++ b/modnet/utils.py
@@ -1,13 +1,16 @@
 import hashlib
 
 
-def get_sha512_of_file(fname):
+def get_hash_of_file(fname, algo="sha512"):
     """ Returns the hexdigest of the SHA512 checksum of the
     file found at fname.
 
     """
     block_size = 65536
-    _hash = hashlib.sha512()
+    if algo.lower() == "md5":
+        _hash = hashlib.md5()
+    else:
+        _hash = hashlib.sha512()
     with open(fname, "rb") as f:
         fb = f.read(block_size)
         while fb:

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,7 @@ setuptools.setup(
     test_suite="modnet.tests",
     extras_require={"test": tests_require},
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
- Added ability to load pre-featurized datasets on figshare directly into `MODData` and removed vestigial MP_2018.6 from git lfs.
- Tweaked setup.py flags for new Python version and updated version number to development tag
- Tag saved/loaded `MODData` with the version used to create them
- Fixed bug in `MODData.get_optimal_df(...)` that was trying to join a dataframe and a numpy array
- Added alias for `MODData.names` as `MODData.target_names` to match `MODNetModel`
- Added ability to specify `n_jobs` in `MODNetFeaturizer` classes, that gets passed into the underlying matminer `MultipleFeaturizers`
- Return an empty dataframe when not requesting a particular set of featurizers (e.g. no structure featurizer) so that it can be joined easily with the results from other featurizers
- Re-enabled cross_nmi calculation when doing feature selection inside `MODData`
