### PR TITLE
Automated validation procedure for hyper parameters

### DIFF
--- a/modnet/model_presets/__init__.py
+++ b/modnet/model_presets/__init__.py
@@ -1,0 +1,7 @@
+""" This submodule defines some MODNet model presets which are used
+    in the fit_preset function.
+"""
+
+from .presets import hyperparam_presets
+
+MODNET_PRESETS = hyperparam_presets

--- a/modnet/model_presets/presets.py
+++ b/modnet/model_presets/presets.py
@@ -1,0 +1,21 @@
+batch_sizes = [64]
+
+learning_rates = [0.02, 0.005]
+
+archs = [(350,[[64],[8],[8],[]]),(350,[[256],[128],[8],[8]]),(1000,[[256],[128],[8],[]])]
+
+epochs = [1000]
+
+losses = ['mse']
+
+activations = ['elu']
+
+hyperparam_presets = []
+for bs in batch_sizes:
+    for lr in learning_rates:
+        for a in archs:
+            for e in epochs:
+                for l in losses:
+                    for act in  activations:
+                        preset = {'batch_size':bs, 'lr':lr, 'n_feat':a[0], 'num_neurons':a[1], 'epochs':e, 'loss':l, 'act':act}
+                        hyperparam_presets.append(preset)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
           'pandas>=0.25.3',
-          'keras>=2.3',
+          'tensorflow>=2.0',
           'pymatgen>=2020.3.13,<2020.9',
           'matminer>=0.6.2',
           'numpy>=1.18.3',


### PR DESCRIPTION
This PR implements a `fit_preset`  function on the MODNetModel class.

The idea is to remove hassle of choosing the right hyperparemeters. This new implementation requires that the user implements only a single loop for testing, or even none if a simple train-test split is chosen.

In an ideal sceneria one would do a cross validation (CV) on a grid of hyper parameters. And at the same time, we also want to have a generalization error, which requires an outer second testing k-fold. This is called nested cross validation. I believe running MODNet on an extensive grid of hyper parameters is not needed, and only a few well working presets should be checked, to come close to the lowest minimum.
Therefore the validation procedure is simplified by a simple train-val (8-2) split, on a few presets (6 at time of writing). Doing a k-fold is not needed here, we only compare a few models, with minimal cost. (cross validation could be used, it can only make the choice better, but with a few presets it is very different from an extensive grid search). However, I suggest using a CV for testing (i.e. generalisation accuracy), as this is really important.

The general workflow for any material-property dataset would be:

- Prepare data (for instance one MODData)
- K-fold test procedure, generating K ( MODData train, MODData test)
- For fold in k folds:
   --> Run `fit_preset` on MODData train => gives you the "best" trained model
   --> Predict on MODData test
- Take mean of test errors as generalisation error.
- The final model is the model trained by applying `fit_preset` on the complete MODData.
