### PR TITLE
Classification implementation

### DIFF
--- a/modnet/models.py
+++ b/modnet/models.py
@@ -36,6 +36,7 @@ class MODNetModel:
         targets: List,
         weights: Dict[str, float],
         num_neurons=([64], [32], [16], [16]),
+        task_type: Optional[Dict[str,int]] = None,
         n_feat=300,
         act="relu",
     ):
@@ -46,6 +47,9 @@ class MODNetModel:
             targets: A nested list of targets names that defines the hierarchy
                 of the output layers.
             weights: The relative loss weights to apply for each target.
+            task_type: Dictionary defining the target types (classification or regression).
+                Should be constructed as follows: key: string giving the target name; value: integer n,
+                 with n=0 for regression and n>=2 for classification with n the number of classes.
             num_neurons: A specification of the model layers, as a 4-tuple
                 of lists of integers. Hidden layers are split into four
                 blocks of `keras.layers.Dense`, with neuron count specified
@@ -60,6 +64,7 @@ class MODNetModel:
 
         self.n_feat = n_feat
         self.weights = weights
+        self.task_type = task_type
 
         self._scaler = None
         self.optimal_descriptors = None
@@ -69,15 +74,20 @@ class MODNetModel:
 
         f_temp = [x for subl in targets for x in subl]
         self.targets_flatten = [x for subl in f_temp for x in subl]
+        if task_type is None:
+            self.task_type = {name: 0 for name in self.targets_flatten}
+        else:
+            self.task_type = task_type
         self._multi_target = len(self.targets_flatten) > 1
 
-        self.build_model(targets, n_feat, num_neurons, act=act)
+        self.build_model(targets, n_feat, num_neurons, act=act, task_type = self.task_type)
 
     def build_model(
         self,
         targets: List,
         n_feat: int,
         num_neurons: Tuple[List[int], List[int], List[int], List[int]],
+        task_type: Optional[Dict[str, int]] = None,
         act: str = "relu",
     ):
         """Builds the Keras model and sets the `self.model` attribute.
@@ -90,6 +100,9 @@ class MODNetModel:
                 of lists of integers. Hidden layers are split into four
                 blocks of `keras.layers.Dense`, with neuron count specified
                 by the elements of the `num_neurons` argument.
+            task_type: Dictionary defining the target types (classification or regression).
+                Should be constructed as follows: key: string giving the target name; value: integer n,
+                with n=0 for regression and n>=2 for classification with n the number of classes.
             act: A string defining a Keras activation function to pass to use
                 in the `keras.layers.Dense` layers.
 
@@ -140,9 +153,15 @@ class MODNetModel:
                         previous_layer = keras.layers.Dense(num_neurons[3][li])(
                             previous_layer
                         )
-                    out = keras.layers.Dense(
-                        1, activation="linear", name=group[prop_idx][pi]
-                    )(previous_layer)
+                    n = task_type[group[prop_idx][pi]]
+                    if n >= 2:
+                        out = keras.layers.Dense(
+                            n,activation='softmax',name=group[prop_idx][pi]
+                            )(previous_layer)
+                    else:
+                        out = keras.layers.Dense(
+                            1, activation="linear", name=group[prop_idx][pi]
+                            )(previous_layer)
                     final_out.append(out)
 
         self.model = keras.models.Model(inputs=f_input, outputs=final_out)
@@ -201,7 +220,14 @@ class MODNetModel:
         x = training_data.get_featurized_df()[
             self.optimal_descriptors[:self.n_feat]
         ].values
-        y = [training_data.df_targets[targ].values.astype(np.float, copy=False) for targ in self.targets_flatten]
+
+        y = []
+        for targ in self.targets_flatten:
+            if self.task_type[targ] >= 2: # Classification
+                y_inner = keras.utils.to_categorical(training_data.df_targets[targ].values,num_classes=self.task_type[targ])
+            else:
+                y_inner = training_data.df_targets[targ].values.astype(np.float, copy=False)
+            y.append(y_inner)
 
         # Scale the input features:
         if self.xscale == "minmax":

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -41,7 +41,7 @@ def test_train_small_model_single_target_classif(subset_moddata, tf_session):
         [[["is_metal"]]],
         weights={"is_metal": 1},
         num_neurons=([16], [8], [8], [4]),
-        task_type={'is_metal':2},
+        num_classes={'is_metal':2},
         n_feat=10,
     )
 

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+ #!/usr/bin/env python
 import pytest
 
 
@@ -22,6 +22,30 @@ def test_train_small_model_single_target(subset_moddata, tf_session):
     model.fit(data, epochs=5)
     model.predict(data)
 
+def test_train_small_model_single_target_classif(subset_moddata, tf_session):
+    """Tests the single target training."""
+    from modnet.models import MODNetModel
+
+    data = subset_moddata
+    # set 'optimal' features manually
+    data.optimal_features = [
+        col for col in data.df_featurized.columns if col.startswith("ElementProperty")
+    ]
+    def is_metal(egap):
+        if egap == 0:
+            return 1
+        else:
+            return 0
+    data.df_targets['is_metal'] = data.df_targets['egap'].apply(is_metal)
+    model = MODNetModel(
+        [[["is_metal"]]],
+        weights={"is_metal": 1},
+        num_neurons=([16], [8], [8], [4]),
+        task_type={'is_metal':2},
+        n_feat=10,
+    )
+
+    model.fit(data, epochs=5)
 
 def test_train_small_model_multi_target(subset_moddata, tf_session):
     """Tests the multi-target training."""

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -116,7 +116,7 @@ def test_nmi_target_classif():
 
     df_feat = pd.DataFrame({'x': x, 'y': y})
     df_target = pd.DataFrame({'z': z})
-    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, n_neighbors=2)
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type="classification", n_neighbors=2)
 
     assert df_nmi_target.shape == (2, 1)
     assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0,0.02)
@@ -134,7 +134,7 @@ def test_nmi_target_classif():
     df_feat = pd.DataFrame({'x': xs, 'y': ys})
     df_target = pd.DataFrame({'z': zs})
 
-    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, n_neighbors=2)
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type="classification", n_neighbors=2)
 
     assert df_nmi_target.shape == (2, 1)
     assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0,0.02)
@@ -145,12 +145,12 @@ def test_nmi_target_classif():
     df_feat = pd.DataFrame({'x': x, 'y': y, 'c': c})
     df_target = pd.DataFrame({'z': z})
 
-    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, n_neighbors=2)
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type="classification", n_neighbors=2)
     assert df_nmi_target.shape == (2, 1)
     assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0, 0.02)
     assert df_nmi_target.loc['y']['z'] == pytest.approx(1.0, 0.02)
 
-    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, drop_constant_features=False, n_neighbors=2)
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type="classification", drop_constant_features=False, n_neighbors=2)
     assert df_nmi_target.shape == (3, 1)
     assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0, 0.02)
     assert df_nmi_target.loc['y']['z'] == pytest.approx(1.0, 0.02)
@@ -165,7 +165,7 @@ def test_nmi_target_classif():
     df_feat = pd.DataFrame({'x': x})
     df_target = pd.DataFrame({'z': z})
 
-    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1)
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type="classification")
     assert df_nmi_target.shape == (1, 1)
     assert df_nmi_target.loc['x']['z'] == pytest.approx(0.0, 0.02)
 
@@ -309,7 +309,7 @@ def test_small_moddata_feature_selection_classif(small_moddata):
     c_nmi = pd.DataFrame([[1, 0, 0.5, 0.5], [0, 1, 0.5, 0.5], [0.5, 0.5, 1, 0.5], [0.5, 0.5, 0.5, 1]],
                              columns=['f1','f2','f3','f4'], index=['f1','f2','f3','f4'])
 
-    classif_md = MODData(['dummy']*1500, targets, target_names=names, task_type=[2])
+    classif_md = MODData(['dummy']*1500, targets, target_names=names, num_classes={"my_classes":3})
     classif_md.df_featurized = pd.DataFrame(features,columns=['f1','f2','f3','f4'])
     classif_md.feature_selection(n=3,cross_nmi=c_nmi)
     assert len(classif_md.get_optimal_descriptors())==3

--- a/modnet/tests/test_preprocessing.py
+++ b/modnet/tests/test_preprocessing.py
@@ -105,6 +105,70 @@ def test_nmi_target():
     assert df_nmi_target.shape == (1, 1)
     assert df_nmi_target.loc['x']['z'] == pytest.approx(0.3417665092162398)
 
+def test_nmi_target_classif():
+    # Test with linear discrete data (should get 1.0 mutual information, or very close due to algorithm used
+    # in mutual_info_regression)
+    npoints = 1500
+    x = np.array([0]*500+[1]*500+[20]*500,dtype='float')
+    y = 2 * x
+    z = np.array(x,dtype='int')
+    print(z)
+
+    df_feat = pd.DataFrame({'x': x, 'y': y})
+    df_target = pd.DataFrame({'z': z})
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, n_neighbors=2)
+
+    assert df_nmi_target.shape == (2, 1)
+    assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0,0.02)
+    assert df_nmi_target.loc['y']['z'] == pytest.approx(1.0,0.02)
+
+    # Same data shuffled
+    # Shuffle the x, y and z
+    indices = np.arange(npoints)
+    np.random.seed(42)
+    np.random.shuffle(indices)
+    xs = x.take(indices)
+    ys = y.take(indices)
+    zs = z.take(indices)
+
+    df_feat = pd.DataFrame({'x': xs, 'y': ys})
+    df_target = pd.DataFrame({'z': zs})
+
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, n_neighbors=2)
+
+    assert df_nmi_target.shape == (2, 1)
+    assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0,0.02)
+    assert df_nmi_target.loc['y']['z'] == pytest.approx(1.0,0.02)
+
+    # Test with one constant feature
+    c = np.ones(npoints) * 1.4
+    df_feat = pd.DataFrame({'x': x, 'y': y, 'c': c})
+    df_target = pd.DataFrame({'z': z})
+
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, n_neighbors=2)
+    assert df_nmi_target.shape == (2, 1)
+    assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0, 0.02)
+    assert df_nmi_target.loc['y']['z'] == pytest.approx(1.0, 0.02)
+
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1, drop_constant_features=False, n_neighbors=2)
+    assert df_nmi_target.shape == (3, 1)
+    assert df_nmi_target.loc['x']['z'] == pytest.approx(1.0, 0.02)
+    assert df_nmi_target.loc['y']['z'] == pytest.approx(1.0, 0.02)
+
+    # Test with unrelated data (grid)
+    x = np.linspace(start=2, stop=5, num=4)
+    z = np.linspace(start=3, stop=7, num=5)
+    x, z = np.meshgrid(x, z)
+    x = x.flatten()
+    z = z.flatten()
+    z = np.array(z / 10, dtype='int')
+    df_feat = pd.DataFrame({'x': x})
+    df_target = pd.DataFrame({'z': z})
+
+    df_nmi_target = nmi_target(df_feat=df_feat, df_target=df_target, task_type=1)
+    assert df_nmi_target.shape == (1, 1)
+    assert df_nmi_target.loc['x']['z'] == pytest.approx(0.0, 0.02)
+
 
 def test_get_cross_nmi():
 
@@ -230,6 +294,26 @@ def test_small_moddata_featurization(small_moddata):
             new.df_featurized[col].to_numpy(),
             old.df_featurized[col].to_numpy(),
         )
+
+def test_small_moddata_feature_selection_classif(small_moddata):
+    """ This test creates classifier MODData and test the feature selection method """
+
+    x1 = np.array([0]*500+[1]*500+[2]*500,dtype='float')
+    x2 = np.random.choice(2,1500)
+    x3 = x1*x2
+    x4 = x1+(x2*0.5)
+    targets = np.array(x1,dtype='int').reshape(-1,1)
+    features = np.array([x1,x2,x3,x4]).T
+    names = ['my_classes']
+
+    c_nmi = pd.DataFrame([[1, 0, 0.5, 0.5], [0, 1, 0.5, 0.5], [0.5, 0.5, 1, 0.5], [0.5, 0.5, 0.5, 1]],
+                             columns=['f1','f2','f3','f4'], index=['f1','f2','f3','f4'])
+
+    classif_md = MODData(['dummy']*1500, targets, target_names=names, task_type=[2])
+    classif_md.df_featurized = pd.DataFrame(features,columns=['f1','f2','f3','f4'])
+    classif_md.feature_selection(n=3,cross_nmi=c_nmi)
+    assert len(classif_md.get_optimal_descriptors())==3
+    assert classif_md.get_optimal_descriptors() == ['f1','f4','f3']
 
 
 def test_merge_ranked():


### PR DESCRIPTION
This PR enables **classification** with MODNet. (+ some basic tests on classification)

### Changes:

- new `task_type` argument in MODData: optional list of integers, which has the same length as the number of targets (properties). The inner values of the list are set to  1 for a classification task and 0 for a regression task. If left to None, all tasks are considered regressions.
- new `task_type` argument in MODNetModel: dictionary defining the target types (classification or regression). Should be constructed as follows: key: string giving the target name; value: integer n, with n=0 for regression and n>=2 for classification with n the number of classes.
- MODData feature selection is based on the scikit-learn `mutual_info_classif` function
- MODNetModel construct n sigmoid neurons for each classification task, with n the number of classes.

### Important notes:
- For single or multi-target target classification, the user should use an appropriate loss functions (e.g. cross entropy loss).
- For mixed classification and regression: should work (not tested); but a good loss function should be used to combine both.

### TODO (other PR or simple commit):
- Update readme accordingly
- Implement a mixed classification and regression loss function (automatically set).