### PR TITLE
fix train-val split when no CV is chosen in fit_preset

### DIFF
--- a/modnet/models.py
+++ b/modnet/models.py
@@ -349,10 +349,9 @@ class MODNetModel:
                 the best-performing settings.
             fast: Used for debugging. If `True`, only fit the first 2 presets and
                 reduce the number of epochs.
-            nested: Whether or not to perform full nested CV. If `True`, set validation
-                data based on the chosen folds, ignoring the `val_fraction` argument. If
-                an integer, use this number of inner CV folds.
-
+            nested: Whether or not to perform full nested CV. If `False` or 0,
+                a simple validation split is performed based on val_fraction argument.
+                If an integer, use this number of inner CV folds, ignoring the `val_fraction` argument.
         """
 
         if callbacks is None:
@@ -379,7 +378,7 @@ class MODNetModel:
         val_losses = 1e20 * np.ones((len(presets),))
 
         num_nested_folds = 5
-        if isinstance(nested, int) and nested != True:
+        if nested:
             num_nested_folds = nested
 
         best_model = None
@@ -399,13 +398,13 @@ class MODNetModel:
                 splits = [next(splits)]
 
             nested_val_losses = []
-            for ind, (train, test) in enumerate(splits):
+            for ind, (train, val) in enumerate(splits):
                 LOG.info("Initialising split #{} preset #{}/{}: {}".format(ind + 1, i + 1, len(presets), params))
 
                 val_params = {}
                 if nested:
-                    train_data, test_data = data.split((train, test))
-                    val_params["val_data"] = test_data
+                    train_data, val_data = data.split((train, val))
+                    val_params["val_data"] = val_data
                 else:
                     val_params["val_fraction"] = val_fraction
                     train_data = data

--- a/modnet/models.py
+++ b/modnet/models.py
@@ -325,7 +325,7 @@ class MODNetModel:
         classification: bool = False,
         refit: bool = True,
         fast: bool = False,
-        nested: [Union[bool, int]] = 5,
+        nested: int = 5,
         callbacks: List[Any] = None,
     ) -> None:
         """Chooses an optimal hyper-parametered MODNet model from different presets.
@@ -349,9 +349,10 @@ class MODNetModel:
                 the best-performing settings.
             fast: Used for debugging. If `True`, only fit the first 2 presets and
                 reduce the number of epochs.
-            nested: Whether or not to perform full nested CV. If `False` or 0,
+            nested: Int specifying whether or not to perform a full nested CV. If 0,
                 a simple validation split is performed based on val_fraction argument.
                 If an integer, use this number of inner CV folds, ignoring the `val_fraction` argument.
+                Note: If set to 1, the value will be overwritten to a default of 5 folds.
         """
 
         if callbacks is None:
@@ -380,6 +381,8 @@ class MODNetModel:
         num_nested_folds = 5
         if nested:
             num_nested_folds = nested
+        if num_nested_folds <= 1:
+            num_nested_folds = 5
 
         best_model = None
         best_n_feat = None

--- a/modnet/preprocessing.py
+++ b/modnet/preprocessing.py
@@ -515,14 +515,14 @@ class MODData:
         if targets is not None:
             # set up dataframe for targets with columns (id, property_1, ..., property_n)
             self.df_targets = pd.DataFrame(targets, index=structure_ids, columns=target_names)
+            # set up number of classes
+            self.num_classes = {name: 0 for name in self.target_names}
+            if num_classes is not None:
+                self.num_classes.update(num_classes)
 
         # set up dataframe for structures with columns (id, structure)
         self.df_structure = pd.DataFrame({'id': structure_ids, 'structure': structures})
         self.df_structure.set_index('id', inplace=True)
-
-        self.num_classes = {name: 0 for name in self.target_names}
-        if num_classes is not None:
-            self.num_classes.update(num_classes)
 
     def featurize(self, fast: bool = False, db_file: str = 'feature_database.pkl', n_jobs=None):
         """ For the input structures, construct many matminer features

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -96,6 +96,8 @@ def test_train_small_model_presets(subset_moddata, tf_session):
     )
 
     model.fit_preset(data, presets=modified_presets, val_fraction=0.2)
+    model.fit_preset(data, presets=modified_presets, nested=0, val_fraction=0.2)
+    model.fit_preset(data, presets=modified_presets, nested=1, val_fraction=0.2)
 
 
 @pytest.mark.skip(msg="Until pickle bug is fixed")

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -95,9 +95,13 @@ def test_train_small_model_presets(subset_moddata, tf_session):
         n_feat=10,
     )
 
-    model.fit_preset(data, presets=modified_presets, val_fraction=0.2)
-    model.fit_preset(data, presets=modified_presets, nested=0, val_fraction=0.2)
-    model.fit_preset(data, presets=modified_presets, nested=1, val_fraction=0.2)
+    # nested=0/False -> no inner loop, so only 1 model
+    # nested=1/True -> inner loop, but default n_folds so 5
+    for num_nested, nested_option in zip([5, 1, 5], [5, 0, 1]):
+        results = model.fit_preset(data, presets=modified_presets, nested=nested_option, val_fraction=0.2)
+        models = results[0]
+        assert len(models) == len(modified_presets)
+        assert len(models[0]) == num_nested
 
 
 @pytest.mark.skip(msg="Until pickle bug is fixed")


### PR DESCRIPTION
Small change in order to enable a simple train-val split in fit_preset. It was not working before.