### PR TITLE
Fix benchmark arguments when performing HP optimisation

### DIFF
--- a/modnet/matbench/benchmark.py
+++ b/modnet/matbench/benchmark.py
@@ -167,10 +167,20 @@ def train_fold(
 
     multi_target = bool(len(target) - 1)
 
+    # If not performing hp_optimization, load model init settings from fit_settings
+    model_settings = {}
+    if not hp_optimization:
+        model_settings = {
+            "num_neurons": fit_settings["num_neurons"],
+            "num_classes": fit_settings.get("num_classes"),
+            "act": fit_settings.get("act"),
+            "n_feat": fit_settings["n_feat"]
+        }
+
     model = MODNetModel(
         target,
         target_weights,
-        **fit_settings
+        **model_settings
     )
 
     if hp_optimization:

--- a/modnet/models.py
+++ b/modnet/models.py
@@ -260,11 +260,11 @@ class MODNetModel:
             val_x = self._scaler.transform(val_x)
             try:
                 val_y = list(
-                    val_data.get_target_df()[self.targets_flatten].values.transpose()
+                    val_data.get_target_df()[self.targets_flatten].values.astype(np.float, copy=False).transpose()
                 )
             except Exception:
                 val_y = list(
-                    val_data.get_target_df().values.transpose()
+                    val_data.get_target_df().values.astype(np.float, copy=False).transpose()
                 )
             validation_data = (val_x, val_y)
         else:

--- a/modnet/tests/test_benchmark.py
+++ b/modnet/tests/test_benchmark.py
@@ -2,7 +2,7 @@
 
 
 def test_train_small_model_benchmark(subset_moddata, tf_session):
-    """Tests the `fit_preset()` method."""
+    """Tests the `matbench_benchmark()` method with optional arguments."""
     from modnet.matbench.benchmark import matbench_benchmark
 
     data = subset_moddata
@@ -19,6 +19,53 @@ def test_train_small_model_benchmark(subset_moddata, tf_session):
         fast=True,
         nested=2,
         n_jobs=1,
+    )
+
+    expected_keys = (
+        "nested_losses",
+        "nested_learning_curves",
+        "best_learning_curves",
+        "predictions",
+        "targets",
+        "errors",
+        "scores",
+        "best_presets",
+    )
+
+    assert all(key in results for key in expected_keys)
+    assert all(len(results[key]) == 5 for key in expected_keys)
+
+
+def test_train_small_model_benchmark_with_extra_args(subset_moddata):
+    """Tests the `matbench_benchmark()` method with some extra settings,
+    parallelised over 2 jobs.
+
+    """
+    from modnet.matbench.benchmark import matbench_benchmark
+
+    data = subset_moddata
+    # set 'optimal' features manually
+    data.optimal_features = [
+        col for col in data.df_featurized.columns if col.startswith("ElementProperty")
+    ]
+
+    # Check that other settings don't break the model creation,
+    # but that they do get used in fitting
+    other_fit_settings = {
+        "epochs": 10,
+        "increase_bs": False,
+        "callbacks": [],
+    }
+
+    results = matbench_benchmark(
+        data,
+        [[["eform"]]],
+        {"eform": 1},
+        fit_settings=other_fit_settings,
+        inner_feat_selection=False,
+        fast=True,
+        nested=2,
+        n_jobs=2,
     )
 
     expected_keys = (


### PR DESCRIPTION
There was a bug introduced (https://github.com/ppdebreuck/modnet/commit/07342e92a5b93da6ba7e1a64fd30d292c3fac0aa#) where too many arguments were passed to the model initialisation, causing a crash. This PR fixes that, and also makes sure that validation data is converted to a float (which was causing the tests to crash when using old MODData's running on multiple processes).