### PR TITLE
A minor fix when running with increasing batch_size scheme

### DIFF
--- a/modnet/matbench/benchmark.py
+++ b/modnet/matbench/benchmark.py
@@ -222,7 +222,7 @@ def train_fold(
                 lr=fit_settings["lr"],
                 epochs=fit_settings["epochs"],
                 batch_size=fit_settings["batch_size"],
-                loss="mse",
+                loss=fit_settings["loss"],
             )
             model.fit(
                 train_data,


### PR DESCRIPTION
This PR adjusts the `increase_bs` training option so that it always uses the selected loss function.