### PR TITLE
Make sure new deps do not get overwritten by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install .[test,dev]
+        pip install --ignore-installed .[test,dev]
 
     - name: Run pre-commit
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install .[test,dev]
 
     - name: Run pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+tensorflow==2.10.0
+tensorflow-probability==0.18.0
+pandas==1.5.0
+pymatgen==2020.8.13
+matminer==0.6.5
+numpy==1.23.4
+scikit-learn==0.23.2


### PR DESCRIPTION
This PR prevents automated pinned dependency updates being overwritten by the upper pins in the setup.py when installed in the CI (@ppdebreuck ~I will just merge this myself and test it~ I do not have the power!).