### PR TITLE
Add support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,35 @@ on:
   push:
     branches:
       - master
-
 jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install pre-commit
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
+        pip install .[dev]
+
+    - name: Run pre-commit
+      run: |
+        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       max-parallel: 3
       matrix:
         python-version: ['3.8', '3.9', '3.10']
@@ -32,24 +55,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install .[test,dev]
-
-    - name: Run pre-commit
-      run: |
-        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
-
-    - name: Check for syntax errors and lint with flake8
-      run: |
-        # check for important errors:
-        # - syntax errors (E9),
-        # - confusion between assignment and equality errors (F63),
-        # - logic errors and syntax errors in type hints (F7)
-        # - undefined name errors (F82)
-        flake8 . \
-            --count --select=E9,F63,F7,F82 --show-source --statistics
-        # display all other linting errors, but never return an error code
-        flake8 . \
-            --count \
-            --statistics
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,19 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+
     steps:
 
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: |
           **/requirements*.txt

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setuptools.setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
Once #101 is merged, we will no longer have any dependency-driven constraints to stick to just Python 3.8. Plus, the CI has been sped up enough that we can afford to triple the testing time (though in parallel) by testing other versions.

This PR simply enables Python 3.9 and 3.10 in the CI.