### PR TITLE
Bump Python version used by RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,14 @@ version: 2
 
 sphinx:
    configuration: docs/source/conf.py
+
 python:
-  version: 3.10
   install:
     - requirements: docs/requirements.txt
     - method: setuptools
       path: docs/
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"


### PR DESCRIPTION
This PR bumps the Python version used by RTD to avoid build failures due to out-of-date SSL.