### PR TITLE
Load model <v3.0 backward compatibility

### DIFF
--- a/modnet/hyper_opt/fit_genetic.py
+++ b/modnet/hyper_opt/fit_genetic.py
@@ -659,7 +659,7 @@ class FitGenetic:
         else:
             ensemble = []
             for m in models[ranking[:refit]]:
-                ensemble += m.model
+                ensemble += m.models
             self.best_model = EnsembleMODNetModel(models=ensemble)
 
         self.results = self.best_individual.genes

--- a/modnet/models/ensemble.py
+++ b/modnet/models/ensemble.py
@@ -432,6 +432,10 @@ class EnsembleMODNetModel(MODNetModel):
         restore inner keras model after running make_picklable
         """
 
+        # backward compatibility for loading models saved <v0.3
+        if not hasattr(self, "models") and hasattr(self, "model"):
+            self.models = self.model
+
         for m in self.models:
             m._restore_model()
 
@@ -442,11 +446,6 @@ class EnsembleMODNetModel(MODNetModel):
             "models",
         ]
         return possible_params
-
-    @property
-    def model(self) -> List[MODNetModel]:
-        """Returns the inner MODNet models. For Backward compatability only."""
-        return self.models
 
 
 def _validate_ensemble_model(


### PR DESCRIPTION
With the `models` refactoring and scale_impute, it is impossible to load <v3.0 models. 