### PR TITLE
Fix issue with `fit_preset` invoking fit incorrectly during refit

### DIFF
--- a/modnet/models/vanilla.py
+++ b/modnet/models/vanilla.py
@@ -674,7 +674,7 @@ class MODNetModel:
             self.fit(
                 data,
                 val_fraction=0,
-                learning_rate=best_preset["lr"],
+                lr=best_preset["lr"],
                 epochs=best_preset["epochs"],
                 batch_size=best_preset["batch_size"],
                 loss=best_preset["loss"],

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -72,7 +72,6 @@ def test_train_small_model_multi_target(subset_moddata, tf_session):
     model.predict(data)
 
 
-@pytest.mark.slow
 def test_train_small_model_presets(subset_moddata, tf_session):
     """Tests the `fit_preset()` method."""
     from modnet.model_presets import gen_presets
@@ -105,6 +104,7 @@ def test_train_small_model_presets(subset_moddata, tf_session):
             nested=nested_option,
             val_fraction=0.2,
             n_jobs=1,
+            refit=True,
         )
         models = results[0]
         assert len(models) == len(modified_presets)
@@ -293,6 +293,7 @@ def test_train_small_bootstrap_multi_target(small_moddata, tf_session):
 def test_train_small_bootstrap_presets(small_moddata, tf_session):
     """Tests the `fit_preset()` method."""
     import time
+
     from modnet.model_presets import gen_presets
     from modnet.models import EnsembleMODNetModel
 


### PR DESCRIPTION
As reported in #180, `fit_preset` incorrectly invokes `.fit()` with `learning_rate` rather than `lr`, but only during the optional `refit` step. This wasn't caught by our CI as we do not test `refit` and also do not run slower tests... I've re-enabled this test for now and made the fix.

Closes #180.

This is currently blocked by #182 