### PR TITLE
Deprecated `BayesianMODNetModel` and update deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools wheel
-        pip install .[dev]
+        pip install .[dev,bayesian]
 
     - name: Run pre-commit
       run: |
@@ -54,7 +54,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install .[test,dev]
+        pip install .[test,dev,bayesian]
 
     - name: Run tests with pytest
       run: |

--- a/modnet/models/__init__.py
+++ b/modnet/models/__init__.py
@@ -1,5 +1,17 @@
+import warnings
+
 from .vanilla import MODNetModel
-from .bayesian import BayesianMODNetModel
+
+try:
+    from .bayesian import BayesianMODNetModel
+except ImportError:
+    warnings.warn(
+        "BayesianMODNetModel is deprecated and may be removed in the future.",
+        DeprecationWarning,
+    )
+
+    BayesianMODNetModel = None
+
 from .ensemble import EnsembleMODNetModel
 
 __all__ = ("MODNetModel", "BayesianMODNetModel", "EnsembleMODNetModel")

--- a/modnet/models/bayesian.py
+++ b/modnet/models/bayesian.py
@@ -4,13 +4,20 @@ Probability.
 
 """
 
-from typing import Optional, Dict, List, Tuple
+import warnings
 from functools import partial
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-import tensorflow_probability as tfp
+
+try:
+    import tensorflow_probability as tfp
+except ImportError:
+    raise RuntimeError(
+        "`tensorflow-probability` is required for Bayesian models: install modnet[bayesian]."
+    )
 
 from modnet import __version__
 from modnet.models.vanilla import MODNetModel
@@ -76,6 +83,11 @@ class BayesianMODNetModel(MODNetModel):
                 for the last output layer
 
         """
+
+        warnings.warn(
+            "BayesianMODNetModel is deprecated and may be removed in the future.",
+            DeprecationWarning,
+        )
 
         self.__modnet_version__ = __version__
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pymatgen==2023.7.20
 matminer==0.8.0
 numpy>=1.20
 scikit-learn==1.2.0
+ruamel.yaml~=0.17,<0.18  # Required until matminer updates

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 tensorflow==2.11.0
-tensorflow-probability==0.19.0
 pandas==1.5.2
 pymatgen==2023.7.20
 matminer==0.8.0
 numpy>=1.20
 scikit-learn==1.2.0
-emmet-core<0.57  # Can remove after https://github.com/materialsproject/api/issues/819

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "matminer~=0.8",
         "numpy>=1.20",
         "scikit-learn~=1.1",
+        "ruamel.yaml~=0.17,<0.18",  # Required until matminer updates
     ],
     tests_require=tests_require,
     test_suite="modnet.tests",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     tests_require=tests_require,
     test_suite="modnet.tests",
     extras_require={
-        "bayesian": ["tensorflow-probability~=0.18"],
+        "bayesian": ["tensorflow-probability==0.18"],
         "test": tests_require,
         "dev": dev_require,
     },

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setuptools.setup(
     install_requires=[
         "pandas~=1.5",
         "tensorflow~=2.10",
-        "tensorflow-probability~=0.18",
         "pymatgen>=2022.9",
         "matminer~=0.8",
         "numpy>=1.20",
@@ -44,6 +43,7 @@ setuptools.setup(
     tests_require=tests_require,
     test_suite="modnet.tests",
     extras_require={
+        "bayesian": ["tensorflow-probability~=0.18"],
         "test": tests_require,
         "dev": dev_require,
     },

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import setuptools
 import re
+
+import setuptools
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -37,8 +38,6 @@ setuptools.setup(
         "matminer~=0.8",
         "numpy>=1.20",
         "scikit-learn~=1.1",
-        "emmet-core<0.57",  # Can remove after https://github.com/materialsproject/api/issues/819
-        "pydantic~=1.10",
     ],
     tests_require=tests_require,
     test_suite="modnet.tests",


### PR DESCRIPTION
This PR deprecates the BayesianMODNetModel, removes the required dep of `tensorflow-probability`, cleans up dep pins that are no longer needed (pydantic, emmet) and adds one for ruamel.yaml.