### PR TITLE
Bump matminer version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tensorflow==2.11.0
 pandas==1.5.2
 pymatgen==2023.7.20
-matminer==0.8.0
-numpy>=1.20
 scikit-learn==1.3.2
-ruamel.yaml~=0.17,<0.18  # Required until matminer updates
+matminer==0.9.1
+numpy>=1.25
+scikit-learn==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,9 @@ setuptools.setup(
         "pandas~=1.5",
         "tensorflow~=2.10",
         "pymatgen>=2023",
-        "matminer~=0.8",
+        "matminer~=0.9",
         "numpy>=1.24",
         "scikit-learn~=1.3",
-        "ruamel.yaml~=0.17,<0.18",  # Required until matminer updates
     ],
     tests_require=tests_require,
     test_suite="modnet.tests",


### PR DESCRIPTION
I've just released matminer 0.9.1 and want to check that it still works here. We may run into issues with the corresponding pymatgen version update.