### PR TITLE
Attempt at bumping pymatgen and matminer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tensorflow==2.11.0
 pandas==1.5.2
-pymatgen==2023.7.20
+pymatgen==2024.3.1
 scikit-learn==1.3.2
-matminer==0.9.1
+matminer==0.9.2
 numpy>=1.25
 scikit-learn==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tensorflow==2.11.0
 pandas==1.5.2
-pymatgen==2024.3.1
 scikit-learn==1.3.2
 matminer==0.9.2
 numpy>=1.25
+pymatgen==2023.11.12
 scikit-learn==1.3.2


### PR DESCRIPTION
Most of the incompatibilities come from our test set up; depickling pymatgen objects isn't version safe so at some point we miss some properties. It will be a very annoying amount of effort to fix this.