### PR TITLE
Properly handle Bayesian model import failure

### DIFF
--- a/modnet/models/bayesian.py
+++ b/modnet/models/bayesian.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 try:
     import tensorflow_probability as tfp
 except ImportError:
-    raise RuntimeError(
+    raise ImportError(
         "`tensorflow-probability` is required for Bayesian models: install modnet[bayesian]."
     )
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "pandas~=1.5",
-        "tensorflow~=2.10",
+        "tensorflow~=2.11,<2.12",
         "pymatgen>=2023",
         "matminer~=0.9",
         "numpy>=1.24",


### PR DESCRIPTION
As above. Currently you cannot import any modnet model from the top-level module without having tf-probability installed.