### PR TITLE
Bug fix when a list of objects is used as the index of df_featurized.

### DIFF
--- a/modnet/models/vanilla.py
+++ b/modnet/models/vanilla.py
@@ -761,8 +761,7 @@ class MODNetModel:
             else:
                 for j, name in enumerate(props):
                     p_dic[name] = p[i][:, j]
-        predictions = pd.DataFrame(p_dic)
-        predictions.index = test_data.structure_ids
+        predictions = pd.DataFrame(p_dic, index=pd.Index(test_data.structure_ids))
 
         return predictions
 


### PR DESCRIPTION
This is more a pandas-related issue, but the fix is easy here. If you want to reproduce easily:
```
import numpy as np
import pandas as pd
from pymatgen.core import Composition

p_dic = {'Shear_modulus_VRH': np.array([10.41488  , 11.641564 , 18.353497 ,  6.309846 ,  4.963774 ,
    5.0492682, 16.049948 , 34.772472 , 19.242157 , 29.776108 ,
    35.512997 , 26.123905 ,  4.2091627, 14.4871435, 39.721558 ,
    57.28263  , 19.148134 , 39.242195 , 27.916546 ,  9.699056 ],
    dtype="float32")
}
index = [
    Composition('K2 Re4 O8 F14'), 
    Composition('O24 Zn6 Mo6'), 
    Composition('O48 Re12 Tl12'),
    Composition('O24 P8 Cs2 Nd2'),
    Composition('O5 Cs4 Sb2'),
    Composition('Bi4 B16 O30'),
    Composition('O2 Cl2 Pr2'),
    Composition('O48 Ge12 Sr12 Y8'), 
    Composition('O20 V4 Ta4'),
    Composition('O38 La2 Ta14'),
    Composition('O12 Mg4 Ge4'),
    Composition('O14 Ca2 Ga8'),
    Composition('Sb16 Te16 O72'),
    Composition('Cs2 Y2 O4'),
    Composition('Li4 Y4 Si4 O16'),
    Composition('Pr4 Sc4 O12'),
    Composition('Pr2 Zr4 F22'),
    Composition('Li12 Gd4 B8 O24'),
    Composition('O12 Si4 Ba4'),
    Composition('F6 Y1 Cs3')
]

pd.DataFrame(p_dic) # works fine
pd.DataFrame(p_dic, index=index) # ValueError: all arrays must be same length
pd.DataFrame(p_dic, index=pd.Index(index)) # works as expected
```