### PR TITLE
[WIP] Validation data generation, removal of loss function overrides

### DIFF
--- a/modnet/hyper_opt/fit_genetic.py
+++ b/modnet/hyper_opt/fit_genetic.py
@@ -458,11 +458,21 @@ class FitGenetic:
             classification=max(self.num_classes.values()) >= 2,
         )
         if not nested:
+            str_col = (
+                [
+                    col_idx
+                    for col_idx, col in enumerate(self.train_data.df_targets.columns)
+                    if self.num_classes[col] >= 2
+                ][0]
+                if max(self.num_classes.values()) >= 2
+                else None
+            )  # TODO different nestings of targets  # TODO not all properties of df_targets may be learned!
             splits = [
                 generate_shuffled_and_stratified_val_split(
                     y=self.train_data.df_targets.values,
                     val_fraction=val_fraction,
                     classification=max(self.num_classes.values()) >= 2,
+                    str_col=str_col,
                 )
             ]
             n_splits = 1

--- a/modnet/hyper_opt/fit_genetic.py
+++ b/modnet/hyper_opt/fit_genetic.py
@@ -4,9 +4,12 @@ import random
 from typing import List, Optional, Dict, Union, Callable
 import numpy as np
 import tensorflow as tf
-from sklearn.model_selection import train_test_split
 from modnet.preprocessing import MODData
-from modnet.models import MODNetModel, EnsembleMODNetModel
+from modnet.models import (
+    MODNetModel,
+    EnsembleMODNetModel,
+    generate_shuffled_and_stratified_val_split,
+)
 from modnet.utils import LOG
 import multiprocessing
 import tqdm
@@ -456,8 +459,10 @@ class FitGenetic:
         )
         if not nested:
             splits = [
-                train_test_split(
-                    range(len(self.train_data.df_featurized)), test_size=val_fraction
+                generate_shuffled_and_stratified_val_split(
+                    y=self.train_data.df_targets.values,
+                    val_fraction=val_fraction,
+                    classification=max(self.num_classes.values()) >= 2,
                 )
             ]
             n_splits = 1

--- a/modnet/models/__init__.py
+++ b/modnet/models/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 
-from .vanilla import MODNetModel
+from .vanilla import MODNetModel, generate_shuffled_and_stratified_val_split
 
 try:
     from .bayesian import BayesianMODNetModel
@@ -14,4 +14,9 @@ except ImportError:
 
 from .ensemble import EnsembleMODNetModel
 
-__all__ = ("MODNetModel", "BayesianMODNetModel", "EnsembleMODNetModel")
+__all__ = (
+    "MODNetModel",
+    "BayesianMODNetModel",
+    "EnsembleMODNetModel",
+    "generate_shuffled_and_stratified_val_split",
+)

--- a/modnet/models/ensemble.py
+++ b/modnet/models/ensemble.py
@@ -13,9 +13,11 @@ import tqdm
 import tensorflow as tf
 
 from sklearn.utils import resample
-from sklearn.model_selection import train_test_split
 
-from modnet.models.vanilla import MODNetModel
+from modnet.models.vanilla import (
+    MODNetModel,
+    generate_shuffled_and_stratified_val_split,
+)
 from modnet import __version__
 from modnet.utils import LOG
 from modnet.preprocessing import MODData
@@ -306,7 +308,11 @@ class EnsembleMODNetModel(MODNetModel):
         )
         if not nested:
             splits = [
-                train_test_split(range(len(data.df_featurized)), test_size=val_fraction)
+                generate_shuffled_and_stratified_val_split(
+                    y=data.df_targets.values,
+                    val_fraction=val_fraction,
+                    classification=classification,
+                )
             ]
             n_splits = 1
         else:

--- a/modnet/models/vanilla.py
+++ b/modnet/models/vanilla.py
@@ -1305,6 +1305,13 @@ class DeprecatedMODNetModel(MODNetModel):
                     )
                 val_y.append(y_inner)
             validation_data = (val_x, val_y)
+        elif val_fraction > 0:
+            x, y, validation_data = generate_shuffled_and_stratified_val_data(
+                x=x,
+                y=y,
+                val_fraction=val_fraction,
+                classification=max(self.num_classes.values()) >= 2,
+            )
         else:
             validation_data = None
 
@@ -1315,7 +1322,7 @@ class DeprecatedMODNetModel(MODNetModel):
 
         # Optionally set up print callback
         if verbose:
-            if val_fraction > 0 or validation_data:
+            if validation_data:
                 if self._multi_target and val_key is not None:
                     val_metric_key = f"val_{val_key}_mae"
                 else:

--- a/modnet/models/vanilla.py
+++ b/modnet/models/vanilla.py
@@ -401,14 +401,11 @@ class MODNetModel:
                     targ = prop[0]
                     if self.multi_label:
                         y_inner = np.stack(val_data.df_targets[targ].values)
-                        if loss is None:
-                            loss = "binary_crossentropy"
                     else:
                         y_inner = tf.keras.utils.to_categorical(
                             val_data.df_targets[targ].values,
                             num_classes=self.num_classes[targ],
                         )
-                        loss = "categorical_crossentropy"
                 else:
                     y_inner = val_data.df_targets[prop].values.astype(
                         np.float64, copy=False

--- a/modnet/models/vanilla.py
+++ b/modnet/models/vanilla.py
@@ -413,11 +413,21 @@ class MODNetModel:
                 val_y.append(y_inner)
             validation_data = (val_x, val_y)
         elif val_fraction > 0:
+            str_col = (
+                [
+                    prop_idx
+                    for prop_idx, prop in enumerate(self.targets_groups)
+                    if self.num_classes[prop[0]] >= 2
+                ][0]
+                if max(self.num_classes.values()) >= 2
+                else None
+            )
             x, y, validation_data = generate_shuffled_and_stratified_val_data(
                 x=x,
                 y=y,
                 val_fraction=val_fraction,
                 classification=max(self.num_classes.values()) >= 2,
+                str_col=str_col,
             )
         else:
             validation_data = None
@@ -1552,18 +1562,18 @@ def map_validate_model(kwargs):
 
 
 def generate_shuffled_and_stratified_val_split(
-    y: list | np.ndarray, val_fraction: float, classification: bool
+    y: list | np.ndarray, val_fraction: float, classification: bool, str_col: int | None
 ):
     """
     Generate train validation split that is shuffled, reproducible and, if classification, stratified.
     """
     if classification:
-        if isinstance(y[0][0], list) or isinstance(y[0][0], np.ndarray):
+        if isinstance(y[str_col][0], list) or isinstance(y[str_col][0], np.ndarray):
             ycv = np.argmax(y[0], axis=1)
         else:
-            ycv = y[0]
+            ycv = y[str_col]
         return train_test_split(
-            range(len(y[0])),
+            range(len(y[str_col])),
             test_size=val_fraction,
             random_state=42,
             shuffle=True,
@@ -1580,12 +1590,13 @@ def generate_shuffled_and_stratified_val_data(
     y: list,
     val_fraction: float,
     classification: bool,
+    str_col: int | None,
 ):
     """
     Generate train and validation data that is shuffled, reproducible and, if classification, stratified.
     """
     train_idx, val_idx = generate_shuffled_and_stratified_val_split(
-        y=y, val_fraction=val_fraction, classification=classification
+        y=y, val_fraction=val_fraction, classification=classification, str_col=str_col
     )
     return (
         x[train_idx],

--- a/modnet/tests/test_model.py
+++ b/modnet/tests/test_model.py
@@ -20,7 +20,7 @@ def test_train_small_model_single_target(subset_moddata, tf_session):
         n_feat=10,
     )
 
-    model.fit(data, epochs=2)
+    model.fit(data, epochs=2, val_fraction=0.15)
     model.predict(data)
     assert not np.isnan(model.evaluate(data))
 
@@ -50,7 +50,7 @@ def test_train_small_model_single_target_classif(subset_moddata, tf_session):
         n_feat=10,
     )
 
-    model.fit(data, epochs=2)
+    model.fit(data, epochs=2, val_fraction=0.15)
     assert not np.isnan(model.evaluate(data))
 
 
@@ -71,7 +71,7 @@ def test_train_small_model_multi_target(subset_moddata, tf_session):
         n_feat=10,
     )
 
-    model.fit(data, epochs=2)
+    model.fit(data, epochs=2, val_fraction=0.15)
     model.predict(data)
     assert not np.isnan(model.evaluate(data))
 


### PR DESCRIPTION
Resolves #228 . Work in progress.

## Overview
- Replaces `train_test_split` with explicit generation of validation data that is reproducible, shuffled and stratified (if classification tasks are present)
- Removes override of loss function for classification tasks

## TODO
- rework determination of classification targets / most imbalanced classification target (?)
- enable passing of loss function for model evaluation for classification tasks